### PR TITLE
EE-9410 Map 'whynot' to 'reasonForNotMatch'

### DIFF
--- a/src/main/resources/db/migration/postgresql/V1_5__UPDATE_TABLE_feedback.sql
+++ b/src/main/resources/db/migration/postgresql/V1_5__UPDATE_TABLE_feedback.sql
@@ -1,0 +1,10 @@
+-- EE-9410 Migrate all 'whynot' entries in detail column of feedback table to be 'reasonForNotMatch'
+
+-- For each row containing 'whynot' as a json key in detail
+-- Get the value of 'whynot'
+-- Add "reasonForNotMatch": "whynotvalue" to json
+-- Remove 'whynot' from json
+
+UPDATE feedback
+SET detail = (detail || ('{"reasonForNotMatch": "' || (detail->>'whynot') || '"}')::jsonb)  - 'whynot'
+WHERE detail ?? 'whynot';


### PR DESCRIPTION
Added Flyway script to replace change any 'whynot' entries to be 'reasonForNotMatch' in the detail column json of the feedback table.